### PR TITLE
Release v2.0.0: Upgrade to .NET 10 LTS

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,27 +4,27 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Azure Functions Isolated Worker Packages (.NET 10 compatible) -->
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.5" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.4.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.5.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.3" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
 
     <!-- Azure Service Packages -->
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
 
     <!-- Microsoft Graph & Identity Packages -->
-    <PackageVersion Include="Microsoft.Graph" Version="5.65.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.5.0" />
-    <PackageVersion Include="Microsoft.Identity.Web.GraphServiceClient" Version="3.5.0" />
+    <PackageVersion Include="Microsoft.Graph" Version="5.100.0" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.Identity.Web.GraphServiceClient" Version="4.3.0" />
 
     <!-- Test Packages -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="xunit" Version="2.6.5" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Azure Functions Isolated Worker Packages -->
+    <!-- Azure Functions Isolated Worker Packages (.NET 10 compatible) -->
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.5" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.4.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />

--- a/deploy/bicep/deployFunction.bicep
+++ b/deploy/bicep/deployFunction.bicep
@@ -91,7 +91,7 @@ var configurations = {
         httpsOnly: true
         siteConfig: {
           alwaysOn: false
-          netFrameworkVersion: 'v6.0'
+          netFrameworkVersion: 'v10.0'
           ftpsState: 'Disabled'
         }
       }
@@ -147,7 +147,7 @@ var configurations = {
         httpsOnly: true
         siteConfig: {
           alwaysOn: false
-          netFrameworkVersion: 'v6.0'
+          netFrameworkVersion: 'v10.0'
           ftpsState: 'Disabled'
         }
       }
@@ -210,7 +210,7 @@ var configurations = {
         httpsOnly: true
         siteConfig: {
           alwaysOn: false
-          netFrameworkVersion: 'v6.0'
+          netFrameworkVersion: 'v10.0'
           ftpsState: 'Disabled'
         }
         virtualNetworkSubnetId: virtualNetwork::fnappSubnet.id

--- a/deploy/resourcemanager/template.json
+++ b/deploy/resourcemanager/template.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "3565077033159323250"
+      "templateHash": "6250529056655100639"
     }
   },
   "parameters": {
@@ -647,7 +647,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.39.26.7824",
-              "templateHash": "3076884505945340631"
+              "templateHash": "4561757347526475827"
             }
           },
           "parameters": {
@@ -904,7 +904,7 @@
                     "httpsOnly": true,
                     "siteConfig": {
                       "alwaysOn": false,
-                      "netFrameworkVersion": "v6.0",
+                      "netFrameworkVersion": "v10.0",
                       "ftpsState": "Disabled"
                     }
                   }
@@ -959,7 +959,7 @@
                     "httpsOnly": true,
                     "siteConfig": {
                       "alwaysOn": false,
-                      "netFrameworkVersion": "v6.0",
+                      "netFrameworkVersion": "v10.0",
                       "ftpsState": "Disabled"
                     }
                   }
@@ -1020,7 +1020,7 @@
                     "httpsOnly": true,
                     "siteConfig": {
                       "alwaysOn": false,
-                      "netFrameworkVersion": "v6.0",
+                      "netFrameworkVersion": "v10.0",
                       "ftpsState": "Disabled"
                     },
                     "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', format('vnet-{0}', resourceGroup().name), 'fnapp-subnet')]"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.424",
+        "version": "10.0.101",
         "rollForward": "latestFeature"
     }
 }

--- a/src/Flattener/CallRecordInsights.Flattener.csproj
+++ b/src/Flattener/CallRecordInsights.Flattener.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Functions/CallRecordInsights.Functions.csproj
+++ b/src/Functions/CallRecordInsights.Functions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>

--- a/src/Functions/Extensions/GraphRequestBuilderAppOnlyExtensions.cs
+++ b/src/Functions/Extensions/GraphRequestBuilderAppOnlyExtensions.cs
@@ -52,6 +52,6 @@ namespace CallRecordInsights.Extensions
         }
 
         private const string APP_NAME = "CallRecordInsights";
-        private const string APP_VERSION = "1.3.0";
+        private const string APP_VERSION = "2.0.0";
     }
 }

--- a/tests/CallRecordInsights.Flattener.Tests/CallRecordInsights.Flattener.Tests.csproj
+++ b/tests/CallRecordInsights.Flattener.Tests/CallRecordInsights.Flattener.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/CallRecordInsights.Functions.Tests/CallRecordInsights.Functions.Tests.csproj
+++ b/tests/CallRecordInsights.Functions.Tests/CallRecordInsights.Functions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

This release upgrades the application from .NET 6.0 to .NET 10 LTS, ensuring continued security support until November 2028.

## .NET 10 LTS Upgrade

**Framework Changes:**
- .NET 6.0 → .NET 10.0 LTS
- global.json SDK: 6.0.424 → 10.0.101
- Azure Functions: v4 (isolated worker model, already migrated in v1.3.0)

**Why .NET 10 vs .NET 8:**
- .NET 8 reaches end-of-support November 10, 2026 (less than 1 year away)
- .NET 10 LTS provides support until November 2028 (nearly 3 years)
- Avoids another migration in 10 months

## Security & Package Updates

**Critical Security Fixes:**
- Microsoft.Identity.Web: 3.5.0 → 4.3.0 (fixes [GHSA-rpq8-q44m-2rpg](https://github.com/advisories/GHSA-rpq8-q44m-2rpg))

**Updated Dependencies:**
- Microsoft.Azure.Functions.Worker: 1.21.0 → 2.51.0
- Microsoft.Azure.Functions.Worker.Sdk: 1.17.0 → 2.0.7
- Microsoft.Graph: 5.65.0 → 5.100.0
- Microsoft.Azure.Cosmos: 3.46.0 → 3.56.0
- Test frameworks: xunit 2.6.5 → 2.9.3, FluentAssertions 6.12.0 → 8.8.0

## Bicep Infrastructure Updates

**Configuration Changes:**
- netFrameworkVersion: 'v6.0' → 'v10.0' (all 3 environments: DevTest, Production, RestrictedProduction)

## Testing & Validation

- All 73 tests passing on .NET 10
- No changes to data format or Cosmos DB schema
- Backward compatible with existing call record data
- No Kusto schema changes

## Deployment Notes

**Azure Configuration Update Required:**

After deployment, the following should already be set from v1.3.0:
```
FUNCTIONS_WORKER_RUNTIME=dotnet-isolated
```

Function App will automatically use .NET 10 runtime based on Bicep configuration.

**Hosting Compatibility:**
- Compatible with all Azure Functions hosting plans (Consumption, Premium, Dedicated) on Windows
- **Linux Note**: Requires Flex Consumption plan for .NET 10 support (not standard Consumption)

## Breaking Changes

**None** - This is a framework upgrade only:
- Cosmos DB schema unchanged
- Kusto table structure unchanged
- API endpoints unchanged
- All function signatures unchanged
- Configuration already updated in v1.3.0

## Timeline & Support

| Version | .NET Version | Support Until | Status |
|---------|--------------|---------------|--------|
| v1.2.0  | .NET 6       | November 2024 | **Unsupported** |
| v1.3.0  | .NET 6       | November 2024 | **Unsupported** |
| v2.0.0  | .NET 10 LTS  | November 2028 | ✅ Active Support |